### PR TITLE
spasql batched queries

### DIFF
--- a/queries/olympics-sparql-queries.sql
+++ b/queries/olympics-sparql-queries.sql
@@ -1,0 +1,197 @@
+-- Query 1 - List the names of every gold medallist (excluding duplicates).
+
+SPARQL
+
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?name
+WHERE {
+ ?instance walls:athlete ?athlete ;
+ walls:medal <http://wallscope.co.uk/resource/olympics/medal/Gold> .
+ ?athlete rdfs:label ?name .
+}
+
+;
+
+-- Query 2 - List the names of every athlete, with at least one medal, alongside their total number of medals (sorted by the number of medals).
+
+SPARQL
+
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?name (COUNT(?name) As ?noOfMedals)
+WHERE {
+  ?instance walls:athlete ?athlete ;
+            walls:medal   ?medal .
+  ?athlete  rdfs:label    ?name .
+}
+GROUP BY ?name
+ORDER BY DESC(?noOfMedals)
+
+;
+
+-- Query 3 - List each country alongside the average height and weight of its athletes (sorted by the average height). 
+
+SPARQL
+
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+SELECT ?countryCode
+       (AVG(?height) As ?avgHeight)
+       (AVG(?weight) As ?avgWeight)
+WHERE {
+ ?noc dbo:ground ?team ;
+      rdfs:label ?countryCode .
+ 
+ ?athlete rdf:type   foaf:Person ;
+          dbo:team   ?team ;
+          dbo:height ?height ;
+          dbo:weight ?weight .
+}
+GROUP BY ?countryCode
+ORDER BY DESC(?avgHeight)
+;
+
+-- Query 4 
+-- List each year alongside the oldest Judo competitor in that year
+
+SPARQL
+
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX dbp: <http://dbpedia.org/property/>
+SELECT ?year (MAX(?age) As ?maxAge)
+WHERE {
+ ?instance walls:games   ?games ;
+           walls:event   ?event ;
+           walls:athlete ?athlete .
+ 
+ ?event rdfs:subClassOf <http://wallscope.co.uk/resource/olympics/sport/Judo> .
+ 
+ ?games dbp:year ?year .
+ 
+ ?athlete foaf:age ?age .
+}
+
+GROUP BY ?year
+;
+
+-- Query 5 - List every athlete with "louis" in their name alongside the city and season that 
+-- they competed in. This query uses regex.
+
+SPARQL
+
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dbp: <http://dbpedia.org/property/>
+SELECT DISTINCT ?name ?cityName ?seasonName
+WHERE {
+ ?instance walls:games   ?games ;
+           walls:athlete ?athlete .
+ 
+ ?games dbp:location ?city ;
+        walls:season ?season .
+ 
+ ?city rdfs:label ?cityName .
+ 
+ ?season rdfs:label ?seasonName .
+ 
+ ?athlete rdfs:label ?name .
+ 
+ Filter (REGEX(lcase(?name),"louis.*"))
+}
+
+;
+
+-- Query 6 - Get a list of every city that an athlete from Serbia and Montenegro competed in. 
+-- Count the number of males and females that ever competed in one of those cities and return these counts.
+
+SPARQL
+
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX dbp: <http://dbpedia.org/property/>
+PREFIX noc: <http://wallscope.co.uk/resource/olympics/NOC/>
+SELECT ?genderName (COUNT(?athlete) AS ?count)
+WHERE {
+  ?instance walls:games   ?games ;
+            walls:athlete ?athlete .
+ 
+  ?games dbp:location ?city .
+ 
+  ?athlete foaf:gender ?gender .
+ 
+  ?gender rdfs:label ?genderName .
+ 
+  {
+    SELECT DISTINCT ?city
+    WHERE {
+    ?instance walls:games   ?games ;
+              walls:athlete ?athlete .
+ 
+    ?athlete dbo:team ?team .
+ 
+    noc:SCG dbo:ground ?team .
+ 
+    ?games dbp:location ?city .
+    }
+  }
+}
+GROUP BY ?genderName
+
+;
+
+-- Query 7 - List every sport's name that has a stored team size in DBpedia and return these sizes next to the corresponding sport.
+
+SPARQL
+
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX dbp: <http://dbpedia.org/property/>
+SELECT ?sportName ?teamSize
+WHERE {
+ ?sport rdf:type   dbo:Sport ;
+        rdfs:label ?sportName .
+ 
+ SERVICE <http://dbpedia.org/sparql> {
+ ?dbsport rdfs:label   ?sportName ;
+          dbo:teamSize ?teamSize .
+ }
+}
+
+;
+
+
+-- QueryFTI - List every athlete with "louis" in their name alongside the city and 
+-- season that they competed in. This query uses each triplestores full text index feature unlike Q5.
+
+SPARQL
+
+PREFIX luc: <http://www.ontotext.com/owlim/lucene#>
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dbp: <http://dbpedia.org/property/>
+SELECT DISTINCT ?name ?cityName ?seasonName
+WHERE {
+ ?instance walls:games   ?games ;
+           walls:athlete ?athlete .
+ 
+ ?games dbp:location ?city ;
+        walls:season ?season .
+ 
+ ?city rdfs:label ?cityName .
+ 
+ ?season rdfs:label ?seasonName .
+ 
+ ?athlete rdfs:label ?name .
+ 
+ ?name luc:myIndex "*louis*" .
+}
+;

--- a/queries/query1.rq
+++ b/queries/query1.rq
@@ -1,7 +1,5 @@
 # Query 1 - List the names of every gold medallist (excluding duplicates).
 
-SPARQL
-
 PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
 PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
 SELECT DISTINCT ?name

--- a/queries/query1.rq
+++ b/queries/query1.rq
@@ -1,0 +1,12 @@
+# Query 1 - List the names of every gold medallist (excluding duplicates).
+
+SPARQL
+
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+SELECT DISTINCT ?name
+WHERE {
+ ?instance walls:athlete ?athlete ;
+ walls:medal <http://wallscope.co.uk/resource/olympics/medal/Gold> .
+ ?athlete rdfs:label ?name .
+}

--- a/queries/query10.rq
+++ b/queries/query10.rq
@@ -1,0 +1,28 @@
+## SPARQL-FED against DBpedia that surfaces DBpedia URIs while also adding ordering via ORDER BY CLAUSE
+
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX dbp: <http://dbpedia.org/property/>
+
+SELECT ?sport ?sportName ?teamSize
+WHERE {
+			{
+			 SELECT DISTINCT ?sportName 
+			 WHERE {
+				 	 ?sport rdf:type  dbo:Sport ;
+			         rdfs:label ?sportName .
+					}
+			}
+ 
+			 SERVICE <http://dbpedia.org/sparql> 
+			 		{
+						SELECT ?sport ?teamSize
+						FROM <http://dbpedia.org>
+						WHERE {
+							 	?sport rdfs:label ?sportName ;
+							             dbo:teamSize ?teamSize .
+							 }
+			 		}
+}
+ORDER BY DESC (?teamSize)

--- a/queries/query2.rq
+++ b/queries/query2.rq
@@ -1,7 +1,5 @@
 ## Query 2 - List the names of every athlete, with at least one medal, alongside their total number of medals (sorted by the number of medals).
 
-SPARQL
-
 PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT ?name (COUNT(?name) As ?noOfMedals)

--- a/queries/query2.rq
+++ b/queries/query2.rq
@@ -1,0 +1,14 @@
+## Query 2 - List the names of every athlete, with at least one medal, alongside their total number of medals (sorted by the number of medals).
+
+SPARQL
+
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?name (COUNT(?name) As ?noOfMedals)
+WHERE {
+  ?instance walls:athlete ?athlete ;
+            walls:medal   ?medal .
+  ?athlete  rdfs:label    ?name .
+}
+GROUP BY ?name
+ORDER BY DESC(?noOfMedals)

--- a/queries/query3.rq
+++ b/queries/query3.rq
@@ -1,0 +1,21 @@
+## Query 3 - List each country alongside the average height and weight of its athletes (sorted by the average height). 
+
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+SELECT ?countryCode
+       (AVG(?height) As ?avgHeight)
+       (AVG(?weight) As ?avgWeight)
+WHERE {
+ ?noc dbo:ground ?team ;
+      rdfs:label ?countryCode .
+ 
+ ?athlete rdf:type   foaf:Person ;
+          dbo:team   ?team ;
+          dbo:height ?height ;
+          dbo:weight ?weight .
+}
+GROUP BY ?countryCode
+ORDER BY DESC(?avgHeight)

--- a/queries/query4.rq
+++ b/queries/query4.rq
@@ -1,0 +1,20 @@
+## Query 4 List each year alongside the oldest Judo competitor in that year
+
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX dbp: <http://dbpedia.org/property/>
+SELECT ?year (MAX(?age) As ?maxAge)
+WHERE {
+ ?instance walls:games   ?games ;
+           walls:event   ?event ;
+           walls:athlete ?athlete .
+ 
+ ?event rdfs:subClassOf <http://wallscope.co.uk/resource/olympics/sport/Judo> .
+ 
+ ?games dbp:year ?year .
+ 
+ ?athlete foaf:age ?age .
+}
+
+GROUP BY ?year

--- a/queries/query5.rq
+++ b/queries/query5.rq
@@ -1,0 +1,21 @@
+## Query 5 - List every athlete with "louis" in their name alongside the city and season that they competed in. This query uses REGEX.
+
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dbp: <http://dbpedia.org/property/>
+SELECT DISTINCT ?name ?cityName ?seasonName
+WHERE {
+ ?instance walls:games   ?games ;
+           walls:athlete ?athlete .
+ 
+ ?games dbp:location ?city ;
+        walls:season ?season .
+ 
+ ?city rdfs:label ?cityName .
+ 
+ ?season rdfs:label ?seasonName .
+ 
+ ?athlete rdfs:label ?name .
+ 
+ Filter (REGEX(lcase(?name),"louis.*"))
+}

--- a/queries/query6.rq
+++ b/queries/query6.rq
@@ -1,0 +1,34 @@
+## Query 6 - Get a list of every city that an athlete from Serbia and Montenegro competed in. Count the number of males and females that ever competed in one of those cities and return these counts.
+
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX dbp: <http://dbpedia.org/property/>
+PREFIX noc: <http://wallscope.co.uk/resource/olympics/NOC/>
+SELECT ?genderName (COUNT(?athlete) AS ?count)
+WHERE {
+  ?instance walls:games   ?games ;
+            walls:athlete ?athlete .
+ 
+  ?games dbp:location ?city .
+ 
+  ?athlete foaf:gender ?gender .
+ 
+  ?gender rdfs:label ?genderName .
+ 
+  {
+    SELECT DISTINCT ?city
+    WHERE {
+    ?instance walls:games   ?games ;
+              walls:athlete ?athlete .
+ 
+    ?athlete dbo:team ?team .
+ 
+    noc:SCG dbo:ground ?team .
+ 
+    ?games dbp:location ?city .
+    }
+  }
+}
+GROUP BY ?genderName

--- a/queries/query7.rq
+++ b/queries/query7.rq
@@ -1,0 +1,19 @@
+Query 7 - List every sport's name that has a stored team size in DBpedia and return these sizes next to the corresponding sport.
+
+SPARQL
+
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX dbp: <http://dbpedia.org/property/>
+SELECT ?sportName ?teamSize
+WHERE {
+		 ?sport rdf:type   dbo:Sport ;
+		        rdfs:label ?sportName .
+ 
+		 SERVICE <http://dbpedia.org/sparql> 
+		 		{
+				 	?dbsport rdfs:label ?sportName ;
+				             dbo:teamSize ?teamSize .
+		 		}
+	}

--- a/queries/query7.rq
+++ b/queries/query7.rq
@@ -1,6 +1,4 @@
-Query 7 - List every sport's name that has a stored team size in DBpedia and return these sizes next to the corresponding sport.
-
-SPARQL
+## Query 7 - List every sport's name that has a stored team size in DBpedia and return these sizes next to the corresponding sport.
 
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/queries/query8.rq
+++ b/queries/query8.rq
@@ -1,0 +1,22 @@
+## QueryFTI - List every athlete with "louis" in their name alongside the city and season that they competed in. This query uses each triplestores full text index feature unlike Q5.
+
+PREFIX luc: <http://www.ontotext.com/owlim/lucene#>
+PREFIX walls: <http://wallscope.co.uk/ontology/olympics/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dbp: <http://dbpedia.org/property/>
+SELECT DISTINCT ?name ?cityName ?seasonName
+WHERE {
+		 ?instance walls:games   ?games ;
+		           walls:athlete ?athlete .
+ 
+		 ?games dbp:location ?city ;
+		        walls:season ?season .
+ 
+		 ?city rdfs:label ?cityName .
+ 
+		 ?season rdfs:label ?seasonName .
+ 
+		 ?athlete rdfs:label ?name .
+ 
+		 ?name luc:myIndex "*louis*" .
+	 }

--- a/queries/query9.rq
+++ b/queries/query9.rq
@@ -1,0 +1,10 @@
+##  Exploring Entities by Entity Types (Classes) using SAMPLE() aggregate function
+
+SELECT DISTINCT SAMPLE(?s) AS 
+       ?sampleEntity COUNT(1) AS 
+       ?entityCount ?o AS ?entityType
+WHERE {
+        ?s a ?o. FILTER (isIRI(?s))
+      } 
+GROUP BY ?o
+ORDER BY DESC 2


### PR DESCRIPTION
This is a conventional .sql file that executes all the queries from within Virtuoso, courtesy of its dual support of both  SPARQL and SQL query languages. 

This powerful feature not only extends SQL (one open standard) using SPARQL (another open standard) it also exposes this power to existing ODBC, JDBC, ADO.NET, OLE DB, and XMLA compliant apps and services .